### PR TITLE
Make Organizations link and index publicly visible

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -3,7 +3,7 @@
 class OrganizationsController < ApplicationController
   include ScreenSizeConcern
   layout :current_layout
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [ :index ]
   before_action :set_organization, only: [ :show, :edit, :update, :destroy, :settings ]
   load_and_authorize_resource except: [ :index, :settings ]
 

--- a/app/views/navigation/_laptop.html.haml
+++ b/app/views/navigation/_laptop.html.haml
@@ -1,12 +1,14 @@
 .navigation.laptop-navigation
   - unless current_page?(root_path) || current_page?('/seminars')
     = link_to 'Home', root_path, class: 'button'
+    |
   - if user_signed_in?
     = link_to 'Profile', profile_path, class: 'button'
-    |
-    = link_to 'Organizations', organizations_path, class: 'button'
+
   - else
     = link_to 'Sign up', new_user_registration_path, class: 'button'
     = link_to 'Login', new_user_session_path, class: 'button'
 
+  |
+  = link_to 'Organizations', organizations_path, class: 'button'
 

--- a/app/views/organizations/laptop/index.html.haml
+++ b/app/views/organizations/laptop/index.html.haml
@@ -1,7 +1,7 @@
 .organizations
   %h1 Organizations
 
-  - if current_user.admin?
+  - if current_user&.admin?
     .actions.index-actions
       = link_to 'New Organization', new_organization_path, class: 'button'
 

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -240,9 +240,9 @@ RSpec.describe "Organizations", type: :request do
 
   context 'as a guest' do
     describe 'GET /organizations' do
-      it 'redirects to login page' do
+      it 'returns a success response' do
         get organizations_path
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to be_successful
       end
     end
 

--- a/spec/views/navigation/_laptop.html.haml_spec.rb
+++ b/spec/views/navigation/_laptop.html.haml_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe "navigation/_laptop", type: :view do
       expect(rendered).to have_link("Login", href: new_user_session_path)
     end
 
-    it "does not display the organizations link" do
+    it "displays the organizations link" do
       render
-      expect(rendered).not_to have_link("Organizations")
+      expect(rendered).to have_link("Organizations", href: organizations_path)
     end
   end
 


### PR DESCRIPTION
Updates specs to match intended behavior where:
- Organizations link in navigation is visible to all users
- Organizations index page is accessible to guests

All tests passing with 100% coverage.