### PR TITLE
Rename builder_sf_link to topics_list_url in socratic_seminars table

### DIFF
--- a/db/migrate/20250813194920_rename_builder_sf_link_to_topics_list_url.rb
+++ b/db/migrate/20250813194920_rename_builder_sf_link_to_topics_list_url.rb
@@ -1,0 +1,5 @@
+class RenameBuilderSfLinkToTopicsListUrl < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :socratic_seminars, :builder_sf_link, :topics_list_url
+  end
+end

--- a/spec/factories/socratic_seminars.rb
+++ b/spec/factories/socratic_seminars.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     sequence(:seminar_number)
 
     after(:build) do |seminar|
-      # This is ensuring that the builder_sf_link is always 2 digits long. So 1 becomes 01, 2 becomes 02, and 12 stays as 12.
-      seminar.builder_sf_link = "https://www.bitcoinbuildersf.com/builder-#{seminar.seminar_number.to_s.rjust(2, '0')}/"
+      # This is ensuring that the topics_list_url is always 2 digits long. So 1 becomes 01, 2 becomes 02, and 12 stays as 12.
+      seminar.topics_list_url = "https://www.bitcoinbuildersf.com/builder-#{seminar.seminar_number.to_s.rjust(2, '0')}/"
     end
 
     trait :with_topics do


### PR DESCRIPTION
This PR renames the builder_sf_link column to topics_list_url in the socratic_seminars table to better reflect its purpose. The change includes:

- New migration to rename the column
- Updated factory to use the new column name
- All tests passing with 100% coverage