### PR TITLE
Add Edit and Delete buttons to topic show page

### DIFF
--- a/app/assets/stylesheets/topics/laptop.css
+++ b/app/assets/stylesheets/topics/laptop.css
@@ -52,6 +52,38 @@
       display: flex;
       align-items: flex-start;
       gap: 0.5em;
+
+      form {
+        margin: 0;
+      }
+
+      .button {
+        width: 100px;
+        text-align: center;
+        background-color: white;
+        border: 1px solid #f89406;
+        color: #f89406;
+        border-radius: 8px;
+        padding: 6px 12px;
+      }
+
+      .button.button-danger {
+        border-color: #dc3545;
+        color: #dc3545;
+        background-color: white;
+        border-radius: 8px !important;
+        padding: 6px 12px;
+      }
+
+      .button:hover {
+        background-color: #f89406;
+        color: white;
+      }
+
+      .button.button-danger:hover {
+        background-color: #dc3545;
+        color: white;
+      }
     }
 
     /* Sections */

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -26,6 +26,11 @@ class Ability
       @user.admin_of?(role.organization)
     end
 
+    # Users can manage topics in seminars they manage
+    can :manage, Topic do |topic|
+      topic.socratic_seminar.manageable_by?(@user)
+    end
+
     # Common abilities for all users (including guests)
     common_abilities
   end

--- a/app/models/socratic_seminar.rb
+++ b/app/models/socratic_seminar.rb
@@ -24,4 +24,13 @@ class SocraticSeminar < ApplicationRecord
 
   scope :upcoming, -> { where("date >= ?", Time.current).order(date: :asc) }
   scope :past, -> { where("date < ?", Time.current).order(date: :desc) }
+
+  # Checks if a user can manage this seminar
+  # @param [User] user The user to check
+  # @return [Boolean] true if the user can manage this seminar
+  def manageable_by?(user)
+    return false unless user
+
+    user.admin? || user.admin_of?(organization)
+  end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -24,6 +24,12 @@ class Topic < ApplicationRecord
     payments.where(paid: true).count
   end
 
+  # Gets the ID of the socratic seminar this topic belongs to
+  # @return [Integer] The ID of the socratic seminar
+  def socratic_seminar_id
+    socratic_seminar&.id
+  end
+
   private
 
   def validate_link

--- a/app/views/topics/edit.html.haml
+++ b/app/views/topics/edit.html.haml
@@ -22,9 +22,9 @@
       = form.text_field :link, size: 60
 
     .field
-      = form.label :socratic_seminar_id
+      = form.label :section_id, "Section"
       %br
-      = form.text_field :socratic_seminar_id, size: 4, value: @topic.socratic_seminar_id
+      = form.collection_select :section_id, @socratic_seminar.sections, :id, :name
 
     .actions
       = form.submit "Update Topic"

--- a/app/views/topics/show.html.haml
+++ b/app/views/topics/show.html.haml
@@ -13,17 +13,17 @@
     });
   }
 
-.container
+.topics
   %p{style: "color: green"}= notice
-  
+
   .page-header-row
     %h1.topic-title= @topic.name
-    - if @admin_mode
+    - if can?(:manage, @topic)
       .header-actions
-        = link_to "Edit", edit_socratic_seminar_topic_path(@socratic_seminar, @topic, mode: 'admin'), class: "button"
-        = button_to "Delete", socratic_seminar_topic_path(@socratic_seminar, @topic, mode: 'admin'), 
-          method: :delete, 
-          class: "button button-danger", 
+        = button_to "Edit", edit_socratic_seminar_topic_path(@socratic_seminar, @topic), method: :get, class: "button"
+        = button_to "Delete", socratic_seminar_topic_path(@socratic_seminar, @topic),
+          method: :delete,
+          class: "button button-danger",
           data: { confirm: "Are you sure you want to delete this topic?" }
 
   - if @topic.link.present?
@@ -42,7 +42,7 @@
       the
       %strong LNURL
       and paste it into a lightning wallet to generate an invoice.
-      
+
       .lnurl-text= @topic.lnurl
 
   .current-status
@@ -51,7 +51,7 @@
       Votes: #{@topic.votes || 0}
     .sats-received-row
       Individual Payments: #{@topic.completed_payments_count}
-    
+
     .sats-received-row
       Sats Received:
       %i.fak.fa-satoshisymbol-solid
@@ -59,7 +59,7 @@
 
   .back-to-topic-list
     = link_to '<- Back To Topics', socratic_seminar_topics_path(@topic.socratic_seminar)
-  
+
   - if @topic.lnurl
     = image_tag "https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=#{CGI.escape(@topic.lnurl)}"
     %br


### PR DESCRIPTION
This PR adds Edit and Delete buttons to the topic show page for users who can manage topics:

- Add Edit and Delete buttons with outlined/bordered style
- Fix topic edit form to use section selector instead of socratic_seminar_id
- Add socratic_seminar_id method to Topic model
- Update button styles to match design