### PR TITLE
Fix RSpec tests and button styling

### DIFF
--- a/app/assets/stylesheets/topics/laptop.css
+++ b/app/assets/stylesheets/topics/laptop.css
@@ -58,7 +58,7 @@
       }
 
       .button {
-        width: 100px;
+        min-width: 120px;
         text-align: center;
         background-color: white;
         border: 1px solid #f89406;

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -2,6 +2,7 @@
 
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include Warden::Test::Helpers

--- a/spec/views/topics/show.html.haml_spec.rb
+++ b/spec/views/topics/show.html.haml_spec.rb
@@ -14,10 +14,15 @@ RSpec.describe "topics/show", type: :view do
     )
   end
 
+  let(:user) { create(:user) }
+  let(:ability) { Ability.new(user) }
+
   before do
     assign(:socratic_seminar, socratic_seminar)
     assign(:topic, topic)
     assign(:admin_mode, false)
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:can?).and_return(false)
   end
 
   context "basic layout" do
@@ -58,14 +63,14 @@ RSpec.describe "topics/show", type: :view do
     end
   end
 
-  context "when in admin mode" do
+  context "when user can manage topic" do
     before do
-      assign(:admin_mode, true)
+      allow(view).to receive(:can?).with(:manage, topic).and_return(true)
       render
     end
 
     it "shows admin controls" do
-      expect(rendered).to have_link("Edit")
+      expect(rendered).to have_button("Edit")
       expect(rendered).to have_button("Delete")
     end
   end


### PR DESCRIPTION
This PR fixes RSpec tests and improves button styling:

- Add Devise test helpers for view specs
- Update topic show view specs to handle authorization
- Fix button expectations in tests
- Update header button styles to be consistent width

All tests are now passing and buttons have consistent styling.