### PR TITLE
Improve mobile landing page layout

### DIFF
--- a/app/assets/stylesheets/landing_page/mobile.css
+++ b/app/assets/stylesheets/landing_page/mobile.css
@@ -7,8 +7,7 @@
     position: relative; /* For absolute footer positioning */
 
     .hero-section {
-      margin-bottom: 2rem;
-      padding: 1rem;
+      padding: 0.3rem;
       background-color: #070b10;
       border-radius: 1rem;
       color: white;
@@ -17,28 +16,32 @@
 
       .hero-content {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
         align-items: center;
-        text-align: center;
-        gap: 1.2em;
-        margin-bottom: 1em;
+        /* gap: 1rem;
+        margin-bottom: 0.5em; */
       }
 
       .hero-logo {
-        height: 200px;
-        width: 200px;
+        width: 100px;
+        flex-shrink: 0;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
       }
 
+      .hero-text {
+        text-align: left;
+      }
+
       .seminar-title {
-        font-size: 2rem;
+        font-size: 1.2rem;
         font-weight: 700;
-        margin-bottom: 0.5rem;
+        /* margin-bottom: 0.25rem; */
       }
 
       .seminar-subtitle {
-        font-size: 1.1rem;
+        font-size: 0.85rem;
         opacity: 0.9;
+        font-weight: 700;
       }
     }
 
@@ -60,9 +63,14 @@
         z-index: 1;
       }
 
+      .upcoming-events-title, .past-events-title {
+        margin-top: 0.75rem;
+        color: #f7931a;
+      }
+
       .events-list {
         .event-row {
-          padding: 1rem;
+          padding: 0.75rem;
           border: 1px solid #e9ecef;
           border-radius: 0.5rem;
           margin-bottom: 1rem;

--- a/app/views/landing_page/mobile/show.html.haml
+++ b/app/views/landing_page/mobile/show.html.haml
@@ -2,15 +2,15 @@
   .hero-section
     .hero-content
       = image_tag 'lightning-bitcoin-logo.png', alt: 'Lightning Voting Logo', class: 'hero-logo'
-      %div
+      .hero-text
         .seminar-title ⚡️ Lightning Voting
-        .seminar-subtitle Vote on topics with Bitcoin Lightning ⚡️
+        .seminar-subtitle Vote on topics with Lightning
 
 
 
   .events-section
     %section.upcoming-events
-      %h2 Upcoming Events
+      %h2.upcoming-events-title Upcoming Events
       .events-list
         - if @upcoming_seminars.any?
           - @upcoming_seminars.each do |seminar|
@@ -19,7 +19,7 @@
           .no-events No upcoming events scheduled
 
     %section.past-events
-      %h2 Past Events
+      %h2.past-events-title Past Events
       .events-list
         - if @past_seminars.any?
           - @past_seminars.each do |seminar|

--- a/spec/views/landing_page/mobile/show.html.haml_spec.rb
+++ b/spec/views/landing_page/mobile/show.html.haml_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "landing_page/mobile/show", type: :view do
   end
 
   it "displays the Lightning Voting subtitle" do
-    expect(rendered).to have_content("Vote on topics with Bitcoin Lightning ⚡️")
+    expect(rendered).to have_content("Vote on topics with Lightning")
   end
 
   it "displays upcoming events section" do


### PR DESCRIPTION
This PR improves the mobile landing page layout by:

- Making the hero section more compact and horizontal
- Aligning logo and text side by side (similar to laptop view)
- Updating subtitle text to be more concise
- Adding orange color to event section titles
- Fixing related specs

All tests are passing and RuboCop shows no issues.