### PR TITLE
Add lightning.vote domains to allowed Action Cable origins

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,9 @@ Rails.application.configure do
     # 'http://buildervoting.com',
     # 'http://www.buildervoting.com',
     "https://buildervoting.com",
-    "https://www.buildervoting.com"
+    "https://www.buildervoting.com",
+    "https://lightning.vote",
+    "https://www.lightning.vote"
   ]
 
   # Fix orgiin vs base_url mismatch


### PR DESCRIPTION
This PR adds both lightning.vote and www.lightning.vote domains to the allowed Action Cable request origins in production environment. This enables WebSocket connections from these domains.