### PR TITLE
Add votable and payable columns to topics

### DIFF
--- a/db/migrate/20250831045138_add_votable_and_payable_to_topics.rb
+++ b/db/migrate/20250831045138_add_votable_and_payable_to_topics.rb
@@ -1,0 +1,9 @@
+class AddVotableAndPayableToTopics < ActiveRecord::Migration[8.0]
+  def change
+    add_column :topics, :votable, :boolean, default: true, null: false
+    add_column :topics, :payable, :boolean, default: true, null: false
+
+    add_index :topics, :votable
+    add_index :topics, :payable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_28_192359) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_31_045138) do
   create_table "organization_roles", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "organization_id", null: false
@@ -108,9 +108,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_192359) do
     t.string "link"
     t.integer "section_id", null: false
     t.integer "parent_topic_id"
+    t.boolean "votable", default: true, null: false
+    t.boolean "payable", default: true, null: false
     t.index ["id"], name: "index_topics_on_id", unique: true
     t.index ["parent_topic_id"], name: "index_topics_on_parent_topic_id"
+    t.index ["payable"], name: "index_topics_on_payable"
     t.index ["section_id"], name: "index_topics_on_section_id"
+    t.index ["votable"], name: "index_topics_on_votable"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     name { Faker::Lorem.sentence }
     votes { 0 }
     sats_received { 0 }
+    votable { true }
+    payable { true }
     association :socratic_seminar
     association :section
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -124,6 +124,16 @@ RSpec.describe Topic, type: :model do
       expect(topic.sats_received).to eq(0)
     end
 
+    it "sets votable to true by default" do
+      topic = build(:topic)
+      expect(topic.votable).to be true
+    end
+
+    it "sets payable to true by default" do
+      topic = build(:topic)
+      expect(topic.payable).to be true
+    end
+
     it "does not set lnurl before creation" do
       topic = build(:topic)
       expect(topic.lnurl).to be_nil
@@ -255,7 +265,9 @@ RSpec.describe Topic, type: :model do
         name: "Test Topic",
         link: "https://example.com",
         votes: 5,
-        sats_received: 1000
+        sats_received: 1000,
+        votable: false,
+        payable: false
       )
       expect(topic).to be_valid
       expect(topic.name).to eq("Test Topic")


### PR DESCRIPTION
This PR adds two new boolean columns to the topics table:

- `votable`: Boolean column (default: true) to control if a topic can be voted on
- `payable`: Boolean column (default: true) to control if a topic can receive payments

Changes include:
- Migration to add both columns with appropriate defaults and null constraints
- Added indexes for better query performance when filtering by these fields
- Updated topic factory to include new fields
- Added tests to verify default values and factory behavior

All tests are passing and no linting issues were found.