### PR TITLE
Update SF Bitcoin Devs schema to handle non-votable and non-payable sections

### DIFF
--- a/app/assets/stylesheets/topics/laptop.css
+++ b/app/assets/stylesheets/topics/laptop.css
@@ -313,7 +313,7 @@
 
     .topic-link a {
       font-size: 0.8em;
-      color: #d3961ae9;
+      color: #d3961ae9 !important;
     }
 
     /* Voting */

--- a/app/assets/stylesheets/topics/laptop.css
+++ b/app/assets/stylesheets/topics/laptop.css
@@ -288,6 +288,11 @@
       }
     }
 
+    /* Remove bottom margin from topic name when no actions are present */
+    .topic-list-item:not(:has(.vote-and-sats-info > *)) .topic-name a {
+      margin-bottom: 0;
+    }
+
     .topic-link {
       font-size: 0.85em;
       color: #666;
@@ -313,7 +318,8 @@
       gap: 0.5em;
       font-weight: 400;
       margin-bottom: 0;
-      min-height: 2em; /* Ensure consistent height even when empty */
+      /* Ensure consistent height even when empty */
+      /* min-height: 2em;  */
     }
 
     .vote-buttons {

--- a/app/assets/stylesheets/topics/laptop.css
+++ b/app/assets/stylesheets/topics/laptop.css
@@ -285,7 +285,13 @@
         font-size: 1.3rem;
         font-weight: 500 !important;
         margin-bottom: 0.3rem;
+        color: #f7931a;
       }
+    }
+
+    /* Make non-interactive topics black */
+    .topic-list-item:not(:has(.vote-and-sats-info > *)) .topic-name a {
+      color: #333;
     }
 
     /* Remove bottom margin from topic name when no actions are present */

--- a/app/assets/stylesheets/topics/laptop.css
+++ b/app/assets/stylesheets/topics/laptop.css
@@ -261,6 +261,12 @@
       background-color: #eff1f66f;
     }
 
+    /* Reduce spacing for topics without actions */
+    .topic-list-item:not(:has(.vote-and-sats-info > *)) {
+      padding: 3px 15px;
+      margin-bottom: 5px;
+    }
+
     .topic-list-item.flash-border {
       animation: flash-border 0.7s cubic-bezier(.23,1.5,.32,1) both;
       border-radius: 8px;

--- a/app/assets/stylesheets/topics/laptop.css
+++ b/app/assets/stylesheets/topics/laptop.css
@@ -289,7 +289,7 @@
     }
 
     /* Remove bottom margin from topic name when no actions are present */
-    .topic-list-item:not(:has(.vote-and-sats-info > *)) .topic-name a {
+    .topic-list-item:not(:has(.vote-and-sats-info > *)) .topic-name {
       margin-bottom: 0;
     }
 
@@ -1177,6 +1177,66 @@
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     }
   }
+}
+
+/* Custom Checkbox Styles */
+.custom-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+  padding-left: 1.75rem;
+  margin-bottom: 0;
+  font-weight: 500;
+  color: #555;
+}
+
+.custom-checkbox input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 0;
+  width: 0;
+}
+
+.custom-checkbox .checkmark {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 20px;
+  width: 20px;
+  background-color: #fff;
+  border: 2px solid #ddd;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+}
+
+.custom-checkbox:hover input ~ .checkmark {
+  border-color: #f7931a;
+}
+
+.custom-checkbox input:checked ~ .checkmark {
+  background-color: #f7931a;
+  border-color: #f7931a;
+}
+
+.custom-checkbox .checkmark:after {
+  content: "";
+  position: absolute;
+  display: none;
+  left: 6px;
+  top: 2px;
+  width: 5px;
+  height: 10px;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.custom-checkbox input:checked ~ .checkmark:after {
+  display: block;
 }
 
 /* Topics New  */

--- a/app/assets/stylesheets/topics/laptop.css
+++ b/app/assets/stylesheets/topics/laptop.css
@@ -307,6 +307,7 @@
       gap: 0.5em;
       font-weight: 400;
       margin-bottom: 0;
+      min-height: 2em; /* Ensure consistent height even when empty */
     }
 
     .vote-buttons {

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -173,6 +173,6 @@ class TopicsController < ApplicationController
   # Whitelists allowed topic parameters
   # @return [ActionController::Parameters] Permitted parameters
   def topic_params
-    params.require(:topic).permit(:name, :link, :section_id)
+    params.require(:topic).permit(:name, :link, :section_id, :votable, :payable)
   end
 end

--- a/app/services/html_schemas/base.rb
+++ b/app/services/html_schemas/base.rb
@@ -27,7 +27,7 @@ module HtmlSchemas
       Rails.logger.info("[Import Topics] #{message}")
     end
 
-    def create_or_skip_topic(section, name, link, parent_topic = nil)
+    def create_or_skip_topic(section, name, link, parent_topic = nil, votable: true, payable: true)
       topic = section.topics.find_by(name: name)
       if topic
         # Check if we need to update the parent relationship
@@ -39,7 +39,13 @@ module HtmlSchemas
         log "Skipping Topic (already exists): #{topic.name}"
       else
         begin
-          topic = section.topics.create!(name: name, link: link, parent_topic: parent_topic)
+          topic = section.topics.create!(
+            name: name,
+            link: link,
+            parent_topic: parent_topic,
+            votable: votable,
+            payable: payable
+          )
           @stats[:topics_created] += 1
           topic_type = parent_topic ? "Subtopic" : "Topic"
           log "  Created #{topic_type}: #{topic.name} #{'- link found' if topic.link.present?} #{'- subtopic of: ' + parent_topic.name if parent_topic}"

--- a/app/services/html_schemas/sf_bitcoin_devs.rb
+++ b/app/services/html_schemas/sf_bitcoin_devs.rb
@@ -5,7 +5,7 @@ require_relative "base"
 module HtmlSchemas
   class SFBitcoinDevsSchema < BaseSchema
     SECTIONS_TO_SKIP = [ "Vote on topics" ]
-    NON_VOTABLE_SECTIONS = [ "intro" ]
+    NON_VOTABLE_SECTIONS = [ "intro", "Live videcoding request", "Vibe Coded App Showcase", "Startup Showcase" ]
     NON_PAYABLE_SECTIONS = [ "intro" ]
 
     def process_sections
@@ -18,7 +18,7 @@ module HtmlSchemas
         section_name = section_id.gsub("-", " ").split.map { |word| word.downcase == "and" ? "and" : word.capitalize }.join(" ")
 
         # Skip sections that match any pattern in SECTIONS_TO_SKIP
-        if SECTIONS_TO_SKIP.any? { |pattern| section_name.downcase == pattern.downcase }
+        if SECTIONS_TO_SKIP.any? { |pattern| normalize_section_name(section_name) == pattern.downcase }
           log "Skipping section: #{section_name}"
           next
         end
@@ -30,12 +30,19 @@ module HtmlSchemas
 
     private
 
+    def normalize_section_name(name)
+      # Remove duration in parentheses and any extra whitespace
+      name.gsub(/\s*\(\d+\s*(?:min|minute)s?\)\s*$/i, "").strip.downcase
+    end
+
     def non_votable_section?(section_name)
-      NON_VOTABLE_SECTIONS.any? { |pattern| section_name.downcase.include?(pattern) }
+      normalized_name = normalize_section_name(section_name)
+      NON_VOTABLE_SECTIONS.any? { |pattern| normalized_name.include?(pattern.downcase) }
     end
 
     def non_payable_section?(section_name)
-      NON_PAYABLE_SECTIONS.any? { |pattern| section_name.downcase.include?(pattern) }
+      normalized_name = normalize_section_name(section_name)
+      NON_PAYABLE_SECTIONS.any? { |pattern| normalized_name.include?(pattern.downcase) }
     end
 
     def process_section(section_name, h2)

--- a/app/services/html_schemas/sf_bitcoin_devs.rb
+++ b/app/services/html_schemas/sf_bitcoin_devs.rb
@@ -4,6 +4,7 @@ require_relative "base"
 
 module HtmlSchemas
   class SFBitcoinDevsSchema < BaseSchema
+    SECTIONS_TO_SKIP = [ "Vote on topics" ]
     NON_VOTABLE_SECTIONS = [ "intro" ]
     NON_PAYABLE_SECTIONS = [ "intro" ]
 
@@ -15,6 +16,12 @@ module HtmlSchemas
 
         # Convert dashes to spaces and capitalize first letter of each word, preserving case of "and"
         section_name = section_id.gsub("-", " ").split.map { |word| word.downcase == "and" ? "and" : word.capitalize }.join(" ")
+
+        # Skip sections that match any pattern in SECTIONS_TO_SKIP
+        if SECTIONS_TO_SKIP.any? { |pattern| section_name.downcase == pattern.downcase }
+          log "Skipping section: #{section_name}"
+          next
+        end
 
         process_section(section_name, h2)
       end

--- a/app/services/html_schemas/sf_bitcoin_devs.rb
+++ b/app/services/html_schemas/sf_bitcoin_devs.rb
@@ -42,8 +42,17 @@ module HtmlSchemas
       section = create_or_skip_section(section_name)
       return unless section
 
-      # Find the next sibling <ul> or <ol> (the list of topics)
-      list = h2.xpath("following-sibling::*").find { |el| el.name == "ul" || el.name == "ol" }
+      # Find all siblings until the next h2
+      siblings = h2.xpath("following-sibling::*")
+      # Find the first list before the next h2
+      list = nil
+      siblings.each do |el|
+        break if el.name == "h2"
+        if el.name == "ul" || el.name == "ol"
+          list = el
+          break
+        end
+      end
       process_list_items(list, section) if list
     end
 

--- a/app/services/html_schemas/sf_bitcoin_devs.rb
+++ b/app/services/html_schemas/sf_bitcoin_devs.rb
@@ -4,8 +4,8 @@ require_relative "base"
 
 module HtmlSchemas
   class SFBitcoinDevsSchema < BaseSchema
-    SECTIONS_TO_SKIP = [ "Vote on topics" ]
-    NON_VOTABLE_SECTIONS = [ "intro", "Live videcoding request", "Vibe Coded App Showcase", "Startup Showcase" ]
+    SECTIONS_TO_SKIP = [ "vote on topics" ]
+    NON_VOTABLE_SECTIONS = [ "intro", "live videcoding request", "vibe coded app showcase", "startup showcase" ]
     NON_PAYABLE_SECTIONS = [ "intro" ]
 
     def process_sections

--- a/app/views/topics/laptop/_form.html.haml
+++ b/app/views/topics/laptop/_form.html.haml
@@ -21,6 +21,20 @@
     = form.text_field :link, placeholder: "https://example.com or www.example.com"
     .field-hint Enter a valid URL (https:// will be auto-added if missing)
 
+  .field
+    = form.label :votable, class: 'custom-checkbox' do
+      = form.check_box :votable
+      %span.checkmark
+      Allow Voting
+    .field-hint Enable up/down voting for this topic
+
+  .field
+    = form.label :payable, class: 'custom-checkbox' do
+      = form.check_box :payable
+      %span.checkmark
+      Allow Lightning Payments
+    .field-hint Enable Lightning payments for this topic
+
   .actions
     = form.submit @submit_text, class: 'button'
     = link_to @back_text, @back_path, class: 'button button-secondary'

--- a/app/views/topics/laptop/index.html.haml
+++ b/app/views/topics/laptop/index.html.haml
@@ -88,7 +88,7 @@
                   .sats-label{"data-action" => "click->topics#toggleSatsLabel"} Sats
                   .sats-received{"data-sats" => topic.sats_received}= topic.sats_received
                 |
-                = link_to "Vote with Lightning ⚡", "https://www.lnurlpay.com/#{topic.lnurl}",
+                = link_to (topic.votable ? "Vote with Lightning ⚡" : "Show appreciation with Lightning ⚡"), "https://www.lnurlpay.com/#{topic.lnurl}",
                   class: "send-btc-link",
                   target: "_blank",
                   rel: "noopener"

--- a/app/views/topics/laptop/index.html.haml
+++ b/app/views/topics/laptop/index.html.haml
@@ -36,11 +36,18 @@
           .qr-code-container{"data-topics-target" => "qrCodeContainer", style: "display: none;"}
             = image_tag "https://api.qrserver.com/v1/create-qr-code/?size=180x180&data=#{CGI.escape("#{ENV['HOSTNAME'] || request.base_url}/socratic_seminars/#{@socratic_seminar.id}/topics")}"
 
-    .voting-instructions
-      %ul
-        %li Vote for free with the Up & Down arrows. One vote per person.
-        %li Send Lightning payments for additional votes. Each individual payment counts as 1 vote. Unlimited Lighting votes per person.
-        %li Votes count for ranking. Lightning payments add votes, but don't count for ranking.
+    - has_votable_topics = @topics.any?(&:votable)
+    - has_payable_topics = @topics.any?(&:payable)
+
+    - if has_votable_topics || has_payable_topics
+      .voting-instructions
+        %ul
+          - if has_votable_topics
+            %li Vote for free with the Up & Down arrows. One vote per person.
+          - if has_payable_topics
+            %li Send Lightning payments for additional votes. Each individual payment counts as 1 vote. Unlimited Lighting votes per person.
+          - if has_votable_topics && has_payable_topics
+            %li Votes count for ranking. Lightning payments add votes, but don't count for ranking.
 
     - @sections.each do |section|
       %h2.section-title= section.name
@@ -55,34 +62,36 @@
                   %span.topic-link
                     = link_to truncate(topic.link, length: 75), topic.link, target: "_blank", rel: "noopener"
             .vote-and-sats-info
-              .vote-count{"data-topics-target" => "voteCount"}= topic.votes || 0
-              .vote-count-label votes
+              - if topic.votable
+                .vote-count{"data-topics-target" => "voteCount"}= topic.votes || 0
+                .vote-count-label votes
 
-              .vote-buttons
-                = button_to upvote_socratic_seminar_topic_path(@socratic_seminar, topic),
-                  method: :post,
-                  class: "vote-button",
-                  disabled: (vote_state == 'up'),
-                  form: { data: { topics_target: 'voteForm', turbo: 'false' } } do
-                  %span.vote-arrow
-                    %i.fas.fa-arrow-up
-                = button_to downvote_socratic_seminar_topic_path(@socratic_seminar, topic),
-                  method: :post,
-                  class: "vote-button",
-                  disabled: (vote_state == 'down'),
-                  form: { data: { topics_target: 'voteForm', turbo: 'false' } } do
-                  %span.vote-arrow
-                    %i.fas.fa-arrow-down
+                .vote-buttons
+                  = button_to upvote_socratic_seminar_topic_path(@socratic_seminar, topic),
+                    method: :post,
+                    class: "vote-button",
+                    disabled: (vote_state == 'up'),
+                    form: { data: { topics_target: 'voteForm', turbo: 'false' } } do
+                    %span.vote-arrow
+                      %i.fas.fa-arrow-up
+                  = button_to downvote_socratic_seminar_topic_path(@socratic_seminar, topic),
+                    method: :post,
+                    class: "vote-button",
+                    disabled: (vote_state == 'down'),
+                    form: { data: { topics_target: 'voteForm', turbo: 'false' } } do
+                    %span.vote-arrow
+                      %i.fas.fa-arrow-down
 
-              |
-              .sats-info
-                .sats-label{"data-action" => "click->topics#toggleSatsLabel"} Sats
-                .sats-received{"data-sats" => topic.sats_received}= topic.sats_received
-              |
-              = link_to "Vote with Lightning ⚡", "https://www.lnurlpay.com/#{topic.lnurl}",
-                class: "send-btc-link",
-                target: "_blank",
-                rel: "noopener"
+              - if topic.payable
+                |
+                .sats-info
+                  .sats-label{"data-action" => "click->topics#toggleSatsLabel"} Sats
+                  .sats-received{"data-sats" => topic.sats_received}= topic.sats_received
+                |
+                = link_to "Vote with Lightning ⚡", "https://www.lnurlpay.com/#{topic.lnurl}",
+                  class: "send-btc-link",
+                  target: "_blank",
+                  rel: "noopener"
 
             - if topic.subtopics.any?
               .subtopics-container

--- a/app/views/topics/laptop/index.html.haml
+++ b/app/views/topics/laptop/index.html.haml
@@ -83,7 +83,8 @@
                       %i.fas.fa-arrow-down
 
               - if topic.payable
-                |
+                - if topic.votable
+                  |
                 .sats-info
                   .sats-label{"data-action" => "click->topics#toggleSatsLabel"} Sats
                   .sats-received{"data-sats" => topic.sats_received}= topic.sats_received

--- a/db/migrate/20250831045138_add_votable_and_payable_to_topics.rb
+++ b/db/migrate/20250831045138_add_votable_and_payable_to_topics.rb
@@ -1,0 +1,9 @@
+class AddVotableAndPayableToTopics < ActiveRecord::Migration[8.0]
+  def change
+    add_column :topics, :votable, :boolean, default: true, null: false
+    add_column :topics, :payable, :boolean, default: true, null: false
+
+    add_index :topics, :votable
+    add_index :topics, :payable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_28_192359) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_31_045138) do
   create_table "organization_roles", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "organization_id", null: false
@@ -108,9 +108,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_192359) do
     t.string "link"
     t.integer "section_id", null: false
     t.integer "parent_topic_id"
+    t.boolean "votable", default: true, null: false
+    t.boolean "payable", default: true, null: false
     t.index ["id"], name: "index_topics_on_id", unique: true
     t.index ["parent_topic_id"], name: "index_topics_on_parent_topic_id"
+    t.index ["payable"], name: "index_topics_on_payable"
     t.index ["section_id"], name: "index_topics_on_section_id"
+    t.index ["votable"], name: "index_topics_on_votable"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -3,6 +3,8 @@ FactoryBot.define do
     name { Faker::Lorem.sentence }
     votes { 0 }
     sats_received { 0 }
+    votable { true }
+    payable { true }
     association :socratic_seminar
     association :section
   end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -124,6 +124,16 @@ RSpec.describe Topic, type: :model do
       expect(topic.sats_received).to eq(0)
     end
 
+    it "sets votable to true by default" do
+      topic = build(:topic)
+      expect(topic.votable).to be true
+    end
+
+    it "sets payable to true by default" do
+      topic = build(:topic)
+      expect(topic.payable).to be true
+    end
+
     it "does not set lnurl before creation" do
       topic = build(:topic)
       expect(topic.lnurl).to be_nil
@@ -255,7 +265,9 @@ RSpec.describe Topic, type: :model do
         name: "Test Topic",
         link: "https://example.com",
         votes: 5,
-        sats_received: 1000
+        sats_received: 1000,
+        votable: false,
+        payable: false
       )
       expect(topic).to be_valid
       expect(topic.name).to eq("Test Topic")

--- a/spec/services/html_schemas/sf_bitcoin_devs_spec.rb
+++ b/spec/services/html_schemas/sf_bitcoin_devs_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe HtmlSchemas::SFBitcoinDevsSchema do
         <ul>
           <li>Wallet Topic</li>
         </ul>
+
+        <h2 id="vote-on-topics">Vote on topics</h2>
+        <ul>
+          <li>Should be completely skipped</li>
+        </ul>
       HTML
     end
 
@@ -50,7 +55,7 @@ RSpec.describe HtmlSchemas::SFBitcoinDevsSchema do
       schema.process_sections
 
       # Check sections were created correctly
-      expect(Section.count).to eq(3)
+      expect(Section.count).to eq(3) # Development, Lightning and Wallets, Intro Section
       expect(Section.pluck(:name)).to contain_exactly(
         "Development",
         "Lightning and Wallets",
@@ -74,6 +79,14 @@ RSpec.describe HtmlSchemas::SFBitcoinDevsSchema do
       # Check links were extracted correctly
       expect(Topic.find_by(name: "Topic 2").link).to eq("https://example.com")
       expect(Topic.find_by(name: "Topic 3").link).to eq("https://example.org")
+    end
+
+    it "completely skips sections in SECTIONS_TO_SKIP" do
+      schema.process_sections
+
+      # Section should not be created at all
+      expect(Section.find_by(name: "Vote on topics")).to be_nil
+      expect(output).to include("Skipping section: Vote On Topics")
     end
 
     it "sets votable and payable to false for intro sections" do
@@ -261,7 +274,7 @@ RSpec.describe HtmlSchemas::SFBitcoinDevsSchema do
     it "updates stats correctly" do
       schema.process_sections
 
-      expect(stats[:sections_created]).to eq(3)
+      expect(stats[:sections_created]).to eq(3) # Development, Lightning and Wallets, Intro Section
       expect(stats[:topics_created]).to eq(8)
       expect(stats[:sections_skipped]).to eq(0)
       expect(stats[:topics_skipped]).to eq(0)
@@ -345,7 +358,7 @@ RSpec.describe HtmlSchemas::SFBitcoinDevsSchema do
         schema.process_sections
 
         expect(stats[:sections_skipped]).to eq(1)
-        expect(stats[:sections_created]).to eq(2)
+        expect(stats[:sections_created]).to eq(2) # Lightning and Wallets, Intro Section (Development is skipped)
         expect(output).to include("Skipping Section (already exists): Development")
       end
     end

--- a/spec/services/html_schemas/sf_bitcoin_devs_spec.rb
+++ b/spec/services/html_schemas/sf_bitcoin_devs_spec.rb
@@ -83,8 +83,23 @@ RSpec.describe HtmlSchemas::SFBitcoinDevsSchema do
       schema.process_sections
 
       # Section should not be created at all
-      expect(Section.find_by(name: "Vote on topics")).to be_nil
+      expect(Section.find_by(name: "Vote On Topics")).to be_nil
       expect(output).to include("Skipping section: Vote On Topics")
+    end
+
+    it "handles section names with durations" do
+      html_with_duration = <<~HTML
+        <h2 id="live-videcoding-request-20-min">Live Videcoding Request (20 min)</h2>
+        <ul><li>Topic</li></ul>
+      HTML
+      doc = Nokogiri::HTML(html_with_duration)
+      schema = described_class.new(doc, socratic_seminar, stats, output)
+      schema.process_sections
+
+      section = Section.find_by(name: "Live Videcoding Request 20 Min")
+      expect(section).to be_present
+      topic = section.topics.first
+      expect(topic.votable).to be false
     end
 
     it "sets votable and payable to false for intro sections" do

--- a/spec/services/html_schemas/sf_bitcoin_devs_spec.rb
+++ b/spec/services/html_schemas/sf_bitcoin_devs_spec.rb
@@ -31,19 +31,17 @@ RSpec.describe HtmlSchemas::SFBitcoinDevsSchema do
           </li>
         </ul>
 
+        <h2 id="vote-on-topics">Vote on topics</h2>
+        <!-- No list here, this section should be skipped -->
+
         <h2 id="intro-section">Intro Section</h2>
         <ul>
-          <li>Should be skipped</li>
+          <li>Intro Topic</li>
         </ul>
 
         <h2 id="lightning-and-wallets">Lightning and Wallets</h2>
         <ul>
           <li>Wallet Topic</li>
-        </ul>
-
-        <h2 id="vote-on-topics">Vote on topics</h2>
-        <ul>
-          <li>Should be completely skipped</li>
         </ul>
       HTML
     end
@@ -94,7 +92,7 @@ RSpec.describe HtmlSchemas::SFBitcoinDevsSchema do
 
       intro_section = Section.find_by(name: "Intro Section")
       expect(intro_section).to be_present
-      intro_topic = intro_section.topics.first
+      intro_topic = intro_section.topics.find_by(name: "Intro Topic")
       expect(intro_topic).to be_present
       expect(intro_topic.votable).to be false
       expect(intro_topic.payable).to be false

--- a/spec/services/import_service_spec.rb
+++ b/spec/services/import_service_spec.rb
@@ -39,7 +39,13 @@ RSpec.describe ImportService do
       expect(output).to include("Created Topic: Topic 1")
       expect(output).to include("Created Topic: Topic 2 with Link - link found")
       expect(output).to include("Created Topic: Topic 3 - link found")
-      expect(output).not_to include("Should be skipped")
+      # Verify intro section topics are created with votable/payable false
+      intro_section = Section.find_by(name: "Intro")
+      expect(intro_section).to be_present
+      intro_topic = intro_section.topics.first
+      expect(intro_topic.name).to eq("Should be skipped")
+      expect(intro_topic.votable).to be false
+      expect(intro_topic.payable).to be false
     end
 
     it 'skips existing sections' do
@@ -59,11 +65,19 @@ RSpec.describe ImportService do
       expect(output).to include("Skipping Topic (already exists): Topic 1")
     end
 
-    it 'skips sections in SECTIONS_TO_SKIP' do
+    it 'handles sections in SECTIONS_TO_SKIP' do
       success, output = described_class.import_sections_and_topics(socratic_seminar)
 
       expect(success).to be true
-      expect(output).to include("Skipping. Section in Skip List: Intro")
+      expect(output).to include("Created Section: Intro")
+
+      # Verify section was created with non-votable/non-payable topics
+      intro_section = Section.find_by(name: "Intro")
+      expect(intro_section).to be_present
+      intro_section.topics.each do |topic|
+        expect(topic.votable).to be false
+        expect(topic.payable).to be false
+      end
     end
 
     it 'handles network errors' do


### PR DESCRIPTION
This PR updates how the SF Bitcoin Devs schema handles intro sections:

- Add NON_VOTABLE_SECTIONS and NON_PAYABLE_SECTIONS arrays (both starting with "intro")
- Add helper methods to check if a section name matches non-votable/non-payable patterns
- Update topic creation to set votable/payable flags based on section matching
- Update tests to verify section handling

Now any section containing "intro" in its name (case-insensitive) will have its topics marked as:
- votable: false
- payable: false

This makes it easier to manage which sections should have these flags disabled, and allows for future expansion by adding more patterns to the arrays.