### PR TITLE
fix: improve mobile topic name wrapping and link styles

### DIFF
--- a/app/assets/stylesheets/topics/mobile.css
+++ b/app/assets/stylesheets/topics/mobile.css
@@ -83,29 +83,49 @@
       .topic-header-row {
         margin-bottom: 0.25rem;
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
         width: 100%;
-
+        flex-wrap: wrap;
+        gap: 0.5rem;
 
         .topic-name {
+          margin-bottom: 0;
           font-size: 1rem;
           font-weight: 500;
+          flex: 1;
+          min-width: 0;
+          word-wrap: break-word;
 
           a {
             color: #f7931a;
             text-decoration: none;
+            display: inline;
+            word-wrap: break-word;
+            overflow-wrap: break-word;
+            hyphens: auto;
           }
 
           .topic-link {
             display: block;
-            font-size: 0.85em;
             color: #666;
             margin-top: 0.25rem;
+            margin-bottom: 0.25rem;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
 
             a {
               color: #d3961ae9;
               text-decoration: none;
+              font-weight: 500;
+              font-size: 0.8em;
+              display: inline-block;
+              max-width: 100%;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
             }
           }
         }
@@ -114,6 +134,12 @@
         .topic-list-item:not(:has(.vote-row, .payment-row)) & {
           .topic-name a {
             color: #333;
+          }
+          .topic-link {
+            margin-bottom: 0;
+          }
+          .topic-link a {
+            color: #d3961ae9;
           }
         }
       }

--- a/app/views/topics/laptop/index.html.haml
+++ b/app/views/topics/laptop/index.html.haml
@@ -38,16 +38,17 @@
 
     - has_votable_topics = @topics.any?(&:votable)
     - has_payable_topics = @topics.any?(&:payable)
+    - has_nonvotable_but_payable_topics = @topics.any? { |topic| !topic.votable && topic.payable }
 
     - if has_votable_topics || has_payable_topics
-      .voting-instructions
+      .voting-instructions.mobile-instructions
         %ul
           - if has_votable_topics
-            %li Vote for free with the Up & Down arrows. One vote per person.
+            %li Vote for free with the Up & Down arrows
           - if has_payable_topics
-            %li Send Lightning payments for additional votes. Each individual payment counts as 1 vote. Unlimited Lighting votes per person.
+            %li= "Send Lightning payments as additional votes #{'or to show appreciation' if has_nonvotable_but_payable_topics}"
           - if has_votable_topics && has_payable_topics
-            %li Votes count for ranking. Lightning payments add votes, but don't count for ranking.
+            %li Votes count for ranking. Lightning payments add votes, but don't count for ranking
 
     - @sections.each do |section|
       %h2.section-title= section.name

--- a/app/views/topics/mobile/index.html.haml
+++ b/app/views/topics/mobile/index.html.haml
@@ -15,14 +15,15 @@
           = render 'topics/mobile/lightning_effects_toggle'
   - has_votable_topics = @topics.any?(&:votable)
   - has_payable_topics = @topics.any?(&:payable)
+  - has_nonvotable_but_payable_topics = @topics.any? { |topic| !topic.votable && topic.payable }
 
   - if has_votable_topics || has_payable_topics
     .voting-instructions.mobile-instructions
       %ul
         - if has_votable_topics
           %li Vote for free with the Up & Down arrows
-        - if has_payable_topics && !has_votable_topics
-          %li Send Lightning payments to show appreciation
+        - if has_payable_topics
+          %li= "Send Lightning payments as additional votes #{'or to show appreciation' if has_nonvotable_but_payable_topics}"
         - if has_votable_topics && has_payable_topics
           %li Votes count for ranking. Lightning payments add votes, but don't count for ranking
 
@@ -64,7 +65,7 @@
                 .sats-label{"data-action" => "click->topics#toggleSatsLabel"} Sats
                 .sats-received{"data-sats" => topic.sats_received}= topic.sats_received
               |
-              = link_to (topic.votable ? "Vote with Lightning ⚡" : "Show appreciation with Lightning ⚡"), "https://www.lnurlpay.com/#{topic.lnurl}",
+              = link_to (topic.votable ? "Vote with Lightning ⚡" : "Show appreciation with ⚡"), "https://www.lnurlpay.com/#{topic.lnurl}",
                 class: "send-btc-link mobile-lightning-button",
                 target: "_blank",
                 rel: "noopener"


### PR DESCRIPTION
## Changes

- Allow topic names to wrap naturally instead of truncating
- Adjust link styles and spacing
- Improve font weights and sizes for better readability

## Testing

1. Open the topics list on a mobile device or narrow browser window
2. Verify that long topic names wrap to multiple lines instead of being truncated
3. Verify that links are properly styled and spaced
4. Check that font weights and sizes are consistent