### PR TITLE
refactor: centralize color variables

### DIFF
--- a/app/assets/stylesheets/application/application.css
+++ b/app/assets/stylesheets/application/application.css
@@ -9,6 +9,9 @@
  * Consider organizing styles into separate files for maintainability.
  */
 
+/* Import variables */
+@import "../variables/colors.css";
+
 /* =========================
    GENERAL PAGE LAYOUT
    ========================= */
@@ -106,8 +109,8 @@ span {
   font-size: 0.95em;
   padding: 0.4em 1.2em;
   background: #fff;
-  color: #f7931a;
-  border: 1.5px solid #f7931a;
+  color: var(--primary-orange);
+  border: 1.5px solid var(--primary-orange);
   border-radius: 8px;
   box-shadow: none;
   font-weight: 600;
@@ -123,8 +126,8 @@ span {
 
 .button:hover:not(:disabled), input[type="submit"]:hover:not([disabled]) {
   background: #fff;
-  color: #f7931a;
-  border: 1.5px solid #f7931a;
+  color: var(--primary-orange);
+  border: 1.5px solid var(--primary-orange);
 }
 
 button:hover {
@@ -240,10 +243,10 @@ button:hover {
 
 @keyframes pop {
   0% { transform: scale(1); }
-  20% { transform: scale(1.4) rotate(-8deg); color: #f7931a; }
-  40% { transform: scale(1.2) rotate(8deg); color: #f7931a; }
-  60% { transform: scale(1.3) rotate(-4deg); color: #f7931a; }
-  80% { transform: scale(1.1) rotate(4deg); color: #f7931a; }
+  20% { transform: scale(1.4) rotate(-8deg); color: var(--primary-orange); }
+  40% { transform: scale(1.2) rotate(8deg); color: var(--primary-orange); }
+  60% { transform: scale(1.3) rotate(-4deg); color: var(--primary-orange); }
+  80% { transform: scale(1.1) rotate(4deg); color: var(--primary-orange); }
   100% { transform: scale(1); color: inherit; }
 }
 
@@ -267,9 +270,9 @@ button:hover {
 }
 
 @keyframes flash-border {
-  0% { box-shadow: 0 0 0 0 #f7931a; border-color: #f7931a; border-width: 0.1px; }
-  30% { box-shadow: 0 0 0 2px #f7931a; border-color: #f7931a; border-width: 0.1px; }
-  70% { box-shadow: 0 0 0 2px #f7931a; border-color: #f7931a; border-width: 0.1px; }
+  0% { box-shadow: 0 0 0 0 var(--primary-orange); border-color: var(--primary-orange); border-width: 0.1px; }
+  30% { box-shadow: 0 0 0 2px var(--primary-orange); border-color: var(--primary-orange); border-width: 0.1px; }
+  70% { box-shadow: 0 0 0 2px var(--primary-orange); border-color: var(--primary-orange); border-width: 0.1px; }
   100% { box-shadow: 0 0 0 0 transparent; border-color: transparent; border-width: 0; }
 }
 
@@ -277,8 +280,8 @@ button:hover {
   font-size: 0.95em;
   padding: 0.4em 1.2em;
   background: #fff;
-  color: #f7931a;
-  border: 1.5px solid #f7931a;
+  color: var(--primary-orange);
+  border: 1.5px solid var(--primary-orange);
   border-radius: 8px;
   box-shadow: none;
   font-weight: 600;
@@ -286,8 +289,8 @@ button:hover {
 }
 .projector-footer-btn:hover, .projector-footer-btn:focus {
   background: #fff;
-  color: #f7931a;
-  border: 1.5px solid #f7931a;
+  color: var(--primary-orange);
+  border: 1.5px solid var(--primary-orange);
 }
 
 .sticky-footer {

--- a/app/assets/stylesheets/auth/shared.css
+++ b/app/assets/stylesheets/auth/shared.css
@@ -80,7 +80,7 @@
 }
 
 .actions input[type="submit"] {
-  background: #f7931a;
+  background: var(--primary-orange);
   color: white;
   border: none;
   cursor: pointer;
@@ -93,6 +93,6 @@
 
 /* Links styling */
 .shared-links a {
-  color: #f7931a;
+  color: var(--primary-orange);
   text-decoration: none;
 }

--- a/app/assets/stylesheets/import_topics.css
+++ b/app/assets/stylesheets/import_topics.css
@@ -15,7 +15,7 @@
 }
 
 .import-results-card {
-  border: 1px solid #f7931a;
+  border: 1px solid var(--primary-orange);
   border-radius: 0.25rem;
   padding: 0.5rem;
   font-size: 0.875rem;

--- a/app/assets/stylesheets/landing_page/laptop.css
+++ b/app/assets/stylesheets/landing_page/laptop.css
@@ -92,7 +92,7 @@
         margin: 2rem 0 1rem;
         color: #333;
         padding-bottom: 0.5rem;
-        border-bottom: 2px solid #f7931a;
+        border-bottom: 2px solid var(--primary-orange);
         position: sticky;
         top: 0;
         background: white;
@@ -128,7 +128,7 @@
                 text-decoration: none;
 
                 &:hover {
-                  color: #f7931a;
+                  color: var(--primary-orange);
                 }
               }
             }

--- a/app/assets/stylesheets/landing_page/mobile.css
+++ b/app/assets/stylesheets/landing_page/mobile.css
@@ -56,7 +56,7 @@
         margin: 1.5rem 0 1rem;
         color: #333;
         padding-bottom: 0.5rem;
-        border-bottom: 2px solid #f7931a;
+        border-bottom: 2px solid var(--primary-orange);
         position: sticky;
         top: 0;
         background: white;
@@ -65,7 +65,7 @@
 
       .upcoming-events-title, .past-events-title {
         margin-top: 0.75rem;
-        color: #f7931a;
+        color: var(--primary-orange);
       }
 
       .events-list {
@@ -87,7 +87,7 @@
                 text-decoration: none;
 
                 &:hover {
-                  color: #f7931a;
+                  color: var(--primary-orange);
                 }
               }
             }

--- a/app/assets/stylesheets/navigation/mobile.css
+++ b/app/assets/stylesheets/navigation/mobile.css
@@ -6,8 +6,8 @@
 }
 
 .mobile-navigation .submit-topic-button {
-  color: #0690b3 !important;
-  border: 1.5px solid #0690b3 !important;
+  color: var(--primary-blue) !important;
+  border: 1.5px solid var(--primary-blue) !important;
   border-radius: 8px;
   padding: 0.75rem 1.5rem;
   font-size: 1rem;

--- a/app/assets/stylesheets/navigation/shared.css
+++ b/app/assets/stylesheets/navigation/shared.css
@@ -2,7 +2,7 @@
 
 .navigation a {
   text-decoration: none;
-  color: #f7931a;
+  color: var(--primary-orange);
   padding: 0.4rem 1rem;
 }
 
@@ -14,8 +14,8 @@
   font-size: 0.95em;
   padding: 0.4em 1.2em;
   background: #fff;
-  color: #f7931a;
-  border: 1.5px solid #f7931a;
+  color: var(--primary-orange);
+  border: 1.5px solid var(--primary-orange);
   border-radius: 8px;
   box-shadow: none;
   font-weight: 600;
@@ -25,8 +25,8 @@
 
 .navigation .button:hover, .navigation .button:focus {
   background: #fff;
-  color: #f7931a;
-  border: 1.5px solid #f7931a;
+  color: var(--primary-orange);
+  border: 1.5px solid var(--primary-orange);
 }
 
 /* Add display flex to align items */

--- a/app/assets/stylesheets/organizations/laptop.css
+++ b/app/assets/stylesheets/organizations/laptop.css
@@ -3,7 +3,7 @@
     /* Seminars Section */
     .seminars-section {
       margin-top: 3rem;
-      border: 1px solid #f7931a;
+      border: 1px solid var(--primary-orange);
       border-radius: 8px;
       padding: 1rem;
       padding-bottom: 1.5rem;
@@ -158,7 +158,7 @@
     .organization-form input[type="email"]:focus,
     .organization-form textarea:focus,
     .organization-form select:focus {
-      border-color: #f7931a;
+      border-color: var(--primary-orange);
       outline: none;
       box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
     }
@@ -243,7 +243,7 @@
 
     .tab.active {
       color: #111827;
-      border-bottom-color: #f7931a;
+      border-bottom-color: var(--primary-orange);
       font-weight: 500;
     }
 
@@ -284,7 +284,7 @@
 
         .button {
           padding: 0.75rem 1.5rem;
-          background: #f7931a;
+          background: var(--primary-orange);
           color: white;
           border: none;
           border-radius: 4px;

--- a/app/assets/stylesheets/qr_scanner.css
+++ b/app/assets/stylesheets/qr_scanner.css
@@ -54,7 +54,7 @@
 
 .qr-scanner-header {
   padding: 16px;
-  background: #f7931a;
+  background: var(--primary-orange);
   color: white;
   display: flex;
   justify-content: space-between;
@@ -97,7 +97,7 @@
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
-  background-color: #f7931a;
+  background-color: var(--primary-orange);
   color: white;
   border: none;
   border-radius: 4px;

--- a/app/assets/stylesheets/sections.css
+++ b/app/assets/stylesheets/sections.css
@@ -38,12 +38,12 @@
 }
 
 .section-form .field .custom-checkbox:hover .checkmark {
-  border-color: #f7931a;
+  border-color: var(--primary-orange);
 }
 
 .section-form .field .custom-checkbox input:checked ~ .checkmark {
-  background-color: #f7931a;
-  border-color: #f7931a;
+  background-color: var(--primary-orange);
+  border-color: var(--primary-orange);
 }
 
 .section-form .field .custom-checkbox .checkmark:after {

--- a/app/assets/stylesheets/socratic_seminars.css
+++ b/app/assets/stylesheets/socratic_seminars.css
@@ -55,7 +55,7 @@
 
 .manage-topics-button.import {
   color: #fff;
-  background-color: #f7931a;
+  background-color: var(--primary-orange);
   border: none;
 }
 
@@ -107,7 +107,7 @@
 
 .seminar-form .field input:focus {
   outline: none;
-  border-color: #f7931a;
+  border-color: var(--primary-orange);
   box-shadow: 0 0 0 3px rgba(247, 147, 26, 0.3);
 }
 
@@ -122,7 +122,7 @@
   font-size: 1rem;
   font-weight: 500;
   color: #fff;
-  background-color: #f7931a;
+  background-color: var(--primary-orange);
   border: none;
   border-radius: 4px;
   cursor: pointer;

--- a/app/assets/stylesheets/socratics_seminars/laptop.css
+++ b/app/assets/stylesheets/socratics_seminars/laptop.css
@@ -88,7 +88,7 @@
 }
 
 .button {
-  border: 1px solid #f7931a;
+  border: 1px solid var(--primary-orange);
 }
 
 .button:hover {
@@ -136,7 +136,7 @@
 .page-header {
   margin-bottom: 2rem;
   padding-bottom: 1rem;
-  border-bottom: 2px solid #f7931a;
+  border-bottom: 2px solid var(--primary-orange);
 }
 
 .page-header-content {
@@ -158,7 +158,7 @@
 }
 
 .seminar-number {
-  color: #f7931a;
+  color: var(--primary-orange);
   font-weight: bold;
 }
 
@@ -187,7 +187,7 @@
 }
 
 .section-title i {
-  color: #f7931a;
+  color: var(--primary-orange);
 }
 
 .payout-amount {
@@ -209,7 +209,7 @@
 
 .amount-unit {
   font-size: 2.5rem;
-  color: #f7931a;
+  color: var(--primary-orange);
 }
 
 .amount-description {
@@ -276,8 +276,8 @@
 .section-name {
   margin: 1.5rem 0 1rem 0;
   font-size: 1.2rem;
-  color: #f7931a;
-  border-left: 3px solid #f7931a;
+  color: var(--primary-orange);
+  border-left: 3px solid var(--primary-orange);
   padding-left: 1rem;
 }
 
@@ -289,7 +289,7 @@
   margin-bottom: 0.5rem;
   background: #f8f9fa;
   border-radius: 4px;
-  border-left: 3px solid #f7931a;
+  border-left: 3px solid var(--primary-orange);
 }
 
 .topic-info {
@@ -300,7 +300,7 @@
 
 .topic-payment-amount {
   font-size: 0.9rem;
-  color: #f7931a;
+  color: var(--primary-orange);
   font-weight: 500;
   display: flex;
   align-items: baseline;
@@ -349,7 +349,7 @@
   position: absolute;
   cursor: pointer;
   top: 0; left: 0; right: 0; bottom: 0;
-  background-color: #f7931a;
+  background-color: var(--primary-orange);
   border-radius: 34px;
   transition: .4s;
 }
@@ -381,7 +381,7 @@
 
 .toggle-label-sats {
   margin-left: 1.4em;
-  color: #f7931a;
+  color: var(--primary-orange);
 }
 
 .toggle-label-btc {
@@ -523,7 +523,7 @@
   }
   50% {
     transform: scale(1.1);
-    color: #f7931a;
+    color: var(--primary-orange);
     text-shadow: 0 0 10px rgba(247, 147, 26, 0.5);
   }
   100% {
@@ -542,7 +542,7 @@
   top: 20px;
   left: 50%;
   transform: translateX(-50%);
-  background: #f7931a;
+  background: var(--primary-orange);
   color: white;
   padding: 16px 32px;
   border-radius: 12px;
@@ -621,7 +621,7 @@
 .seminar-form input[type="email"]:focus,
 .seminar-form textarea:focus,
 .seminar-form select:focus {
-  border-color: #f7931a;
+  border-color: var(--primary-orange);
   outline: none;
   box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
 }
@@ -737,7 +737,7 @@
 .section-form input[type="email"]:focus,
 .section-form textarea:focus,
 .section-form select:focus {
-  border-color: #f7931a;
+  border-color: var(--primary-orange);
   outline: none;
   box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
 }

--- a/app/assets/stylesheets/topics/laptop.css
+++ b/app/assets/stylesheets/topics/laptop.css
@@ -90,7 +90,7 @@
         position: absolute;
         cursor: pointer;
         top: 0; left: 0; right: 0; bottom: 0;
-        background-color: #f7931a;
+        background-color: var(--primary-orange);
         border-radius: 34px;
         transition: .4s;
       }
@@ -121,12 +121,12 @@
       }
 
       .toggle-label-units {
-        color: #f7931a;
+        color: var(--primary-orange);
         margin-right: 0.5em;
       }
 
       .toggle-label-sats {
-        color: #f7931a;
+        color: var(--primary-orange);
       }
 
       .toggle-label-btc {
@@ -145,7 +145,7 @@
       }
 
       .toggle-label-lightning {
-        color: #f7931a;
+        color: var(--primary-orange);
         font-weight: 600;
         user-select: none;
       }
@@ -161,7 +161,7 @@
       }
 
       .toggle-label-qr {
-        color: #f7931a;
+        color: var(--primary-orange);
         font-weight: 600;
         user-select: none;
       }
@@ -208,8 +208,8 @@
       }
 
       .submit-topic-button {
-        color: #0690b3 !important;
-        border: 1.5px solid #0690b3 !important;
+        color: var(--primary-blue) !important;
+        border: 1.5px solid var(--primary-blue) !important;
         border-radius: 8px;
         padding: 0.75rem 1.5rem;
         font-size: 1rem;
@@ -285,7 +285,7 @@
         font-size: 1.3rem;
         font-weight: 500 !important;
         margin-bottom: 0.3rem;
-        color: #f7931a;
+        color: var(--primary-orange);
       }
     }
 
@@ -313,7 +313,7 @@
 
     .topic-link a {
       font-size: 0.8em;
-      color: #d3961ae9 !important;
+      color: var(--secondary-orange) !important;
     }
 
     /* Voting */
@@ -337,7 +337,7 @@
     }
 
     .vote-button {
-      background: #f7931a;
+      background: var(--primary-orange);
       color: #fff;
       border: none;
       border-radius: 6px;
@@ -549,7 +549,7 @@
 .topic-form input[type="text"]:focus,
 .topic-form textarea:focus,
 .topic-form select:focus {
-  border-color: #f7931a;
+  border-color: var(--primary-orange);
   outline: none;
   box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
 }
@@ -662,7 +662,7 @@
         position: absolute;
         cursor: pointer;
         top: 0; left: 0; right: 0; bottom: 0;
-        background-color: #f7931a;
+        background-color: var(--primary-orange);
         border-radius: 34px;
         transition: .4s;
       }
@@ -693,7 +693,7 @@
       }
 
       .toggle-label-sats {
-        color: #f7931a;
+        color: var(--primary-orange);
       }
 
       .toggle-label-btc {
@@ -753,7 +753,7 @@
       gap: 0.5rem;
 
       i {
-        color: #f7931a;
+        color: var(--primary-orange);
       }
     }
 
@@ -773,7 +773,7 @@
         .amount-value {
           font-size: 2rem;
           font-weight: 700;
-          color: #f7931a;
+          color: var(--primary-orange);
         }
       }
 
@@ -819,7 +819,7 @@
       gap: 0.5rem;
 
       .button {
-        background: #f7931a;
+        background: var(--primary-orange);
         color: white;
         border: none;
         border-radius: 8px;
@@ -881,7 +881,7 @@
       }
 
       .bolt11-label i {
-        color: #f7931a;
+        color: var(--primary-orange);
         margin-right: 0.5rem;
       }
 
@@ -903,7 +903,7 @@
 
       .bolt11-input:focus {
         outline: none;
-        border-color: #f7931a;
+        border-color: var(--primary-orange);
         box-shadow: 0 0 0 2px rgba(247, 147, 26, 0.25);
       }
 
@@ -914,7 +914,7 @@
       }
 
       .bolt11-help i {
-        color: #f7931a;
+        color: var(--primary-orange);
         margin-right: 0.25rem;
       }
     }
@@ -1002,7 +1002,7 @@
 
             .sats-received {
               font-weight: 600;
-              color: #f7931a;
+              color: var(--primary-orange);
             }
           }
         }
@@ -1043,7 +1043,7 @@
     margin-bottom: 1rem;
 
     .topic-link-show {
-      color: #f7931a;
+      color: var(--primary-orange);
       text-decoration: none;
       font-size: 1rem;
       line-height: 1.4;
@@ -1071,7 +1071,7 @@
     }
 
     .lnurl-link {
-      color: #f7931a;
+      color: var(--primary-orange);
       text-decoration: none;
       font-weight: 600;
 
@@ -1096,7 +1096,7 @@
     }
 
     .copy-button {
-      background: #f7931a;
+      background: var(--primary-orange);
       color: white;
       border: none;
       border-radius: 4px;
@@ -1152,7 +1152,7 @@
     margin: 1.5rem 0;
 
     a {
-      color: #f7931a;
+      color: var(--primary-orange);
       text-decoration: none;
       font-weight: 600;
 
@@ -1220,12 +1220,12 @@
 }
 
 .custom-checkbox:hover input ~ .checkmark {
-  border-color: #f7931a;
+  border-color: var(--primary-orange);
 }
 
 .custom-checkbox input:checked ~ .checkmark {
-  background-color: #f7931a;
-  border-color: #f7931a;
+  background-color: var(--primary-orange);
+  border-color: var(--primary-orange);
 }
 
 .custom-checkbox .checkmark:after {

--- a/app/assets/stylesheets/topics/mobile.css
+++ b/app/assets/stylesheets/topics/mobile.css
@@ -98,7 +98,7 @@
           word-wrap: break-word;
 
           a {
-            color: #f7931a;
+            color: var(--primary-orange);
             text-decoration: none;
             display: inline;
             word-wrap: break-word;
@@ -117,7 +117,7 @@
             white-space: nowrap;
 
             a {
-              color: #d3961ae9;
+              color: var(--secondary-orange);
               text-decoration: none;
               font-weight: 500;
               font-size: 0.8em;
@@ -139,7 +139,7 @@
             margin-bottom: 0;
           }
           .topic-link a {
-            color: #d3961ae9;
+            color: var(--secondary-orange);
           }
         }
       }
@@ -166,7 +166,7 @@
         }
 
         .vote-button {
-          background: #f7931a;
+          background: var(--primary-orange);
           color: #fff;
           border: none;
           border-radius: 6px;
@@ -218,7 +218,7 @@
         }
 
         .mobile-lightning-button {
-          color: #f7931a;
+          color: var(--primary-orange);
           text-decoration: none;
           font-weight: 500;
 
@@ -294,7 +294,7 @@
       position: absolute;
       cursor: pointer;
       top: 0; left: 0; right: 0; bottom: 0;
-      background-color: #f7931a;
+      background-color: var(--primary-orange);
       border-radius: 34px;
       transition: .4s;
     }
@@ -325,7 +325,7 @@
     }
 
     .toggle-label-sats {
-      color: #f7931a;
+      color: var(--primary-orange);
     }
 
     .toggle-label-btc {
@@ -342,7 +342,7 @@
     }
 
     .toggle-label-lightning {
-      color: #f7931a;
+      color: var(--primary-orange);
       font-weight: 600;
       user-select: none;
     }
@@ -370,7 +370,7 @@
       .topic-link-show {
         display: block;
         word-break: break-all;
-        color: #f7931a;
+        color: var(--primary-orange);
         text-decoration: none;
         font-size: 1rem;
         line-height: 1.4;
@@ -456,7 +456,7 @@
       width: 100%;
       padding: 0.75rem;
       margin: 1rem 0;
-      color: #f7931a;
+      color: var(--primary-orange);
       background-color: white;
       border: 1px solid #e9ecef;
       border-radius: 0.5rem;
@@ -598,7 +598,7 @@
 
         &:focus {
           outline: none;
-          border-color: #f7931a;
+          border-color: var(--primary-orange);
           box-shadow: 0 0 0 2px rgba(247, 147, 26, 0.2);
         }
       }
@@ -648,7 +648,7 @@
       }
 
       .mobile-submit-button {
-        background-color: #f7931a;
+        background-color: var(--primary-orange);
         color: white;
 
         &:hover {
@@ -667,8 +667,8 @@
 
         &:hover {
           background-color: #f8f9fa;
-          border-color: #f7931a;
-          color: #f7931a;
+          border-color: var(--primary-orange);
+          color: var(--primary-orange);
         }
       }
     }

--- a/app/assets/stylesheets/topics/shared.css
+++ b/app/assets/stylesheets/topics/shared.css
@@ -15,11 +15,11 @@
 .lightning-bolt svg {
   width: 100%;
   height: 100%;
-  filter: drop-shadow(0 0 20px #f7931a) drop-shadow(0 0 40px #f7931a);
+  filter: drop-shadow(0 0 20px var(--primary-orange)) drop-shadow(0 0 40px var(--primary-orange));
 }
 
 .lightning-bolt path {
-  fill: #f7931a;
+  fill: var(--primary-orange);
   animation: lightning-bolt-flash 0.5s ease-in-out infinite;
 }
 
@@ -44,7 +44,7 @@
 
 @keyframes lightning-bolt-flash {
   0%, 100% {
-    fill: #f7931a;
+    fill: var(--primary-orange);
     filter: brightness(1);
   }
   50% {
@@ -76,7 +76,7 @@
   top: 20px;
   left: 50%;
   transform: translateX(-50%);
-  background: #f7931a;
+  background: var(--primary-orange);
   color: white;
   padding: 12px 24px;
   border-radius: 8px;

--- a/app/assets/stylesheets/variables/colors.css
+++ b/app/assets/stylesheets/variables/colors.css
@@ -1,0 +1,14 @@
+/* =========================
+   COLOR VARIABLES
+   ========================= */
+
+:root {
+  /* Primary Colors */
+  --primary-orange: #f7931a;
+  --primary-blue: #0690b3;
+
+  /* Secondary Colors */
+  --secondary-orange: rgba(211, 150, 26, 0.914);
+
+  /* Add more color variables here as needed */
+}


### PR DESCRIPTION
## Changes

- Move color variables to variables/colors.css
- Replace hardcoded colors with CSS variables
- Update imports to use centralized color variables

## Testing
1. Verify all orange colors (#f7931a) are now using var(--primary-orange)
2. Check that all styles are applied correctly
3. Verify no visual regressions in:
   - Topic list views
   - Navigation
   - Buttons and links