### PR TITLE
fix: improve HTML schema handling

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -4,6 +4,7 @@
 # @attr [String] name The name of the section
 # @attr [Integer] socratic_seminar_id ID of the seminar this section belongs to
 # @attr [Integer] order The display order of this section within the seminar
+# @attr [Boolean] allow_public_submissions Whether public submissions are allowed for this section
 class Section < ApplicationRecord
   # @!attribute socratic_seminar
   #   @return [SocraticSeminar] The seminar this section belongs to

--- a/app/services/html_schemas/base.rb
+++ b/app/services/html_schemas/base.rb
@@ -66,7 +66,13 @@ module HtmlSchemas
         begin
           # Set order to the next available position
           next_order = @seminar.sections.count
-          section = Section.create!(name: section_name, socratic_seminar: @seminar, order: next_order)
+          public_submissions_allowed = !non_publicly_submitable_section?(section_name)
+          section = Section.create!(
+            name: section_name,
+            socratic_seminar: @seminar,
+            order: next_order,
+            allow_public_submissions: public_submissions_allowed
+          )
           @stats[:sections_created] += 1
           log "Created Section: #{section.name} (order: #{next_order})"
         rescue ActiveRecord::RecordInvalid => e

--- a/app/services/html_schemas/base.rb
+++ b/app/services/html_schemas/base.rb
@@ -93,5 +93,9 @@ module HtmlSchemas
       match = direct_text.match(/(https?:\/\/[^\s]+|www\.[^\s]+)/)
       match[1] if match
     end
+
+    def non_publicly_submitable_section?(section_name)
+      false # By default, all sections allow public submissions
+    end
   end
 end

--- a/app/services/html_schemas/sf_bitcoin_devs.rb
+++ b/app/services/html_schemas/sf_bitcoin_devs.rb
@@ -4,18 +4,18 @@ require_relative "base"
 
 module HtmlSchemas
   class SFBitcoinDevsSchema < BaseSchema
+    # !!!! You must restart the Heroku dynos or local rails server for this to take effect !!!
     SECTIONS_TO_SKIP = [ "vote on topics" ]
-    NON_VOTABLE_SECTIONS = [ "intro", "live videcoding request", "vibe coded app showcase", "startup showcase" ]
-    NON_PAYABLE_SECTIONS = [ "intro" ]
+    NON_VOTABLE_SECTIONS = [ "intro", "live videcoding request", "vibe coded app showcase", "startup showcase", "housekeeping", "chain weather report" ]
+    NON_PAYABLE_SECTIONS = [ "intro", "housekeeping", "chain weather report" ]
+    NON_PUBLICLY_SUBMITABLE = [ "intro", "startup showcase", "vibe coded app showcase", "housekeeping", "chain weather report" ]
+    # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     def process_sections
       log "Using SFBitcoinDevs schema parser"
       @doc.css("h2").each do |h2|
-        section_id = h2["id"]
-        next unless section_id.present?
-
-        # Convert dashes to spaces and capitalize first letter of each word, preserving case of "and"
-        section_name = section_id.gsub("-", " ").split.map { |word| word.downcase == "and" ? "and" : word.capitalize }.join(" ")
+        section_name = h2.text.strip
+        next unless section_name.present?
 
         # Skip sections that match any pattern in SECTIONS_TO_SKIP
         if SECTIONS_TO_SKIP.any? { |pattern| normalize_section_name(section_name) == pattern.downcase }
@@ -45,9 +45,25 @@ module HtmlSchemas
       NON_PAYABLE_SECTIONS.any? { |pattern| normalized_name.include?(pattern.downcase) }
     end
 
+    def non_publicly_submitable_section?(section_name)
+      normalized_name = normalize_section_name(section_name)
+      NON_PUBLICLY_SUBMITABLE.any? { |pattern| normalized_name.include?(pattern.downcase) }
+    end
+
     def process_section(section_name, h2)
       section = create_or_skip_section(section_name)
       return unless section
+
+      # Log section attributes
+      if non_votable_section?(section_name)
+        log "Section '#{section_name}' created as non-votable"
+      end
+      if non_payable_section?(section_name)
+        log "Section '#{section_name}' created as non-payable"
+      end
+      if non_publicly_submitable_section?(section_name)
+        log "Section '#{section_name}' created as non-publicly submittable"
+      end
 
       # Find all siblings until the next h2
       siblings = h2.xpath("following-sibling::*")

--- a/spec/services/import_service_spec.rb
+++ b/spec/services/import_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ImportService do
       expect(output).to include("Created Topic: Topic 2 with Link - link found")
       expect(output).to include("Created Topic: Topic 3 - link found")
       # Verify intro section topics are created with votable/payable false
-      intro_section = Section.find_by(name: "Intro")
+      intro_section = Section.find_by(name: "Intro Section")
       expect(intro_section).to be_present
       intro_topic = intro_section.topics.first
       expect(intro_topic.name).to eq("Should be skipped")
@@ -69,10 +69,10 @@ RSpec.describe ImportService do
       success, output = described_class.import_sections_and_topics(socratic_seminar)
 
       expect(success).to be true
-      expect(output).to include("Created Section: Intro")
+      expect(output).to include("Created Section: Intro Section")
 
       # Verify section was created with non-votable/non-payable topics
-      intro_section = Section.find_by(name: "Intro")
+      intro_section = Section.find_by(name: "Intro Section")
       expect(intro_section).to be_present
       intro_section.topics.each do |topic|
         expect(topic.votable).to be false


### PR DESCRIPTION
## Changes

- Add default non_publicly_submitable_section? method to BaseSchema
  - By default, all sections allow public submissions
  - Individual schemas can override this behavior
- Fix section name handling in ImportService tests
- Update test expectations to match actual HTML content

## Testing
1. Run RSpec tests to verify all tests pass
2. Verify that sections are created with correct public submission settings
3. Check that section names are handled correctly in tests